### PR TITLE
sles12sp3/rmblast : removed dependency from boost lib

### DIFF
--- a/sles12sp3/rmblast.cyg
+++ b/sles12sp3/rmblast.cyg
@@ -29,7 +29,7 @@ MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/ncbi-blast-${MAALI_TOOL_VERSION}+-src"
 MAALI_TOOL_TYPE="bio-apps"
 
 # tool pre-requisites
-MAALI_TOOL_PREREQ="boost/1.62.0"
+MAALI_TOOL_PREREQ=""
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
@@ -51,7 +51,7 @@ function maali_build {
   maali_run "patch -p1 < isb-2.6.0+-changes-vers2.patch"
   cd "$MAALI_TOOL_BUILD_DIR/c++"
 
-  maali_run "./configure --with-mt --prefix=$MAALI_INSTALL_DIR --without-debug --with-boost=$MAALI_BOOST_HOME"
+  maali_run "./configure --with-mt --prefix=$MAALI_INSTALL_DIR --without-debug"
   maali_run "make"
   maali_run "make install"
 }


### PR DESCRIPTION
This follows discussion in CR-1230 (https://support.pawsey.org.au/portal/browse/CR-1230), 
to reduce the number of BOOST versions on Zeus.
This was the only dependency on boost/1.62.0.
The updated build recipe reflects the installation instructions for RMBLAST as found on its website:
http://www.repeatmasker.org/RMBlast.html

