### PR TITLE
Singularity for MPI updated for all clusters

### DIFF
--- a/centos7.6/singularity-openmpi.cyg
+++ b/centos7.6/singularity-openmpi.cyg
@@ -1,0 +1,48 @@
+##############################################################################
+# maali cygnet file for singularity 
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+Singularity enables users to have full control of their environment. Singularity 
+containers can be used to package entire scientific workflows, software and 
+libraries, and even data.
+
+For further information see https://sylabs.io/singularity
+
+EOF
+
+# specify which compilers we want to build the tool with
+# Should only build it with the system gcc as it just forms the container host
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_SYSTEM_GCC"
+
+# specify the architectures we want to build the library on
+MAALI_TOOL_CPU_TARGET="na"
+
+# tool pre-requisites modules needed to install this new tool/package
+MAALI_TOOL_PREREQ="singularity/$MAALI_TOOL_VERSION"
+
+# URL to download the source code from
+MAALI_URL=""
+
+# location we are downloading the source code to
+MAALI_DST=""
+
+# where the unpacked source code is located
+#MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
+MAALI_TOOL_BUILD_DIR=""
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# this only creates a module file
+MAALI_REMODULE=1
+
+# for auto-building module files
+MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='\"/usr/lib64:/pawsey/centos7.6/devel/\"..os.getenv\(\"CPU_TARGET\"\)..\"/gcc/8.3.0/openmpi-ucx/4.0.2/lib:/pawsey/centos7.6/devel/gcc/4.8.5/ucx/1.6.0/lib\"'
+MAALI_MODULE_QUOTES_SINGULARITYENV_LD_LIBRARY_PATH=off
+MAALI_MODULE_SET_SINGULARITYENV_OMPI_MCA_btl_openib_allow_ib='1'
+MAALI_MODULE_SET_SINGULARITYENV_FI_PROVIDER_PATH=' '
+MAALI_MODULE_SET_SINGULARITYENV_I_MPI_ROOT=' '
+
+##############################################################################

--- a/centos7.6/singularity.cyg
+++ b/centos7.6/singularity.cyg
@@ -37,9 +37,13 @@ MAALI_TOOL_TYPE="devel"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
-MAALI_MODULE_SET_SINGULARITY_BINDPATH='/astro,/group,/scratch,/pawsey'
+MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='/usr/lib64:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/libfabric/lib:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/lib/release:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/lib'
+MAALI_MODULE_SET_SINGULARITY_BINDPATH='/astro,/group,/scratch,/pawsey,/etc/dat.conf,/etc/libibverbs.d,/usr/lib64/libdaplofa.so.2,/usr/lib64/libdaplofa.so.2.0.0,/usr/lib64/libdat2.so.2,/usr/lib64/libdat2.so.2.0.0,/usr/lib64/libibverbs.so,/usr/lib64/libibverbs.so.1,/usr/lib64/libibverbs.so.1.0.0,/usr/lib64/libmlx5.so.1,/usr/lib64/libnl-3.so.200,/usr/lib64/libnl-3.so.200.23.0,/usr/lib64/libnl-cli-3.so.200,/usr/lib64/libnl-cli-3.so.200.23.0,/usr/lib64/libnl-genl-3.so.200,/usr/lib64/libnl-genl-3.so.200.23.0,/usr/lib64/libnl-idiag-3.so.200,/usr/lib64/libnl-idiag-3.so.200.23.0,/usr/lib64/libnl-nf-3.so.200,/usr/lib64/libnl-nf-3.so.200.23.0,/usr/lib64/libnl-route-3.so.200,/usr/lib64/libnl-route-3.so.200.23.0,/usr/lib64/librdmacm.so.1,/usr/lib64/librdmacm.so.1.0.0,/usr/lib64/libpciaccess.so.0,/usr/lib64/libpmi.so.0,/usr/lib64/libpmi2.so.0,/usr/lib64/libnuma.so.1,/usr/lib64/slurm/libslurmfull.so,/usr/lib64/libmlx4-rdmav2.so,/usr/lib64/librxe-rdmav2.so,/usr/lib64/libmlx5-rdmav2.so,/usr/lib64/libpsm2.so.2'
 MAALI_MODULE_SET_SINGULARITY_CACHEDIR='os.getenv\(\"MYGROUP\"\)..\"/.singularity\"'
 MAALI_MODULE_QUOTES_SINGULARITY_CACHEDIR=off
+MAALI_MODULE_SET_SINGULARITYENV_OMPI_MCA_btl_openib_allow_ib='1'
+MAALI_MODULE_SET_SINGULARITYENV_FI_PROVIDER_PATH='/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/libfabric/lib/prov'
+MAALI_MODULE_SET_SINGULARITYENV_I_MPI_ROOT='/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi'
 
 ##############################################################################
 

--- a/mwa_sles12sp4/singularity-openmpi.cyg
+++ b/mwa_sles12sp4/singularity-openmpi.cyg
@@ -1,0 +1,49 @@
+##############################################################################
+# maali cygnet file for singularity 
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+Singularity enables users to have full control of their environment. Singularity 
+containers can be used to package entire scientific workflows, software and 
+libraries, and even data.
+
+For further information see https://sylabs.io/singularity
+
+EOF
+
+# specify which compilers we want to build the tool with
+# Should only build it with the system gcc as it just forms the container host
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_SYSTEM_GCC"
+
+# specify the architectures we want to build the library on
+MAALI_TOOL_CPU_TARGET="na"
+
+# tool pre-requisites modules needed to install this new tool/package
+MAALI_TOOL_PREREQ="singularity/$MAALI_TOOL_VERSION"
+
+# URL to download the source code from
+MAALI_URL=""
+
+# location we are downloading the source code to
+MAALI_DST=""
+
+# where the unpacked source code is located
+#MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
+MAALI_TOOL_BUILD_DIR=""
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# this only creates a module file
+MAALI_REMODULE=1
+
+# for auto-building module files
+MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='\"/usr/lib64:/pawsey/mwa_sles12sp5/devel/\"..os.getenv\(\"CPU_TARGET\"\)..\"/gcc/8.3.0/openmpi-ucx/4.0.3/lib:/pawsey/mwa_sles12sp5/devel/gcc/4.8.5/ucx/1.6.0/lib\"'
+MAALI_MODULE_QUOTES_SINGULARITYENV_LD_LIBRARY_PATH=off
+MAALI_MODULE_SET_SINGULARITYENV_OMPI_MCA_btl_openib_allow_ib=' '
+MAALI_MODULE_SET_SINGULARITYENV_FI_PROVIDER_PATH=' '
+MAALI_MODULE_SET_SINGULARITYENV_I_MPI_ROOT=' '
+MAALI_MODULE_SET_SINGULARITYENV_OMPI_MCA_btl='^openib'
+
+##############################################################################

--- a/mwa_sles12sp4/singularity.cyg
+++ b/mwa_sles12sp4/singularity.cyg
@@ -37,10 +37,15 @@ MAALI_TOOL_TYPE="devel"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
-MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='/usr/lib64:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/lib'
+MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='/usr/lib64:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/libfabric/lib:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/lib/release:/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/lib'
 MAALI_MODULE_SET_SINGULARITY_BINDPATH='/astro,/pawsey,/etc/dat.conf,/etc/libibverbs.d,/usr/lib64/libdaplofa.so.2,/usr/lib64/libdaplofa.so.2.0.0,/usr/lib64/libdat2.so.2,/usr/lib64/libdat2.so.2.0.0,/usr/lib64/libibverbs.so,/usr/lib64/libibverbs.so.1,/usr/lib64/libibverbs.so.1.0.0,/usr/lib64/libmlx5.so.1,/usr/lib64/libnl-3.so.200,/usr/lib64/libnl-3.so.200.18.0,/usr/lib64/libnl-cli-3.so.200,/usr/lib64/libnl-cli-3.so.200.18.0,/usr/lib64/libnl-genl-3.so.200,/usr/lib64/libnl-genl-3.so.200.18.0,/usr/lib64/libnl-idiag-3.so.200,/usr/lib64/libnl-idiag-3.so.200.18.0,/usr/lib64/libnl-nf-3.so.200,/usr/lib64/libnl-nf-3.so.200.18.0,/usr/lib64/libnl-route-3.so.200,/usr/lib64/libnl-route-3.so.200.18.0,/usr/lib64/librdmacm.so.1,/usr/lib64/librdmacm.so.1.0.0,/usr/lib64/libpciaccess.so.0,/usr/lib64/libpmi.so.0,/usr/lib64/libpmi2.so.0,/usr/lib64/libnuma.so.1,/usr/lib64/slurm/libslurmfull.so,/usr/lib64/libmlx4-rdmav2.so,/usr/lib64/librxe-rdmav2.so,/usr/lib64/libmlx5-rdmav2.so'
 MAALI_MODULE_SET_SINGULARITY_CACHEDIR='\"/astro/\"..os.getenv\(\"PAWSEY_PROJECT\"\)..\"/\"..os.getenv\(\"USER\"\)..\"/.singularity\"'
 MAALI_MODULE_QUOTES_SINGULARITY_CACHEDIR=off
+MAALI_MODULE_SET_SINGULARITYENV_OMPI_MCA_btl_openib_allow_ib='1'
+MAALI_MODULE_SET_SINGULARITYENV_FI_PROVIDER_PATH='/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi/intel64/libfabric/lib/prov'
+MAALI_MODULE_SET_SINGULARITYENV_I_MPI_ROOT='/pawsey/intel/19.0.5/compilers_and_libraries/linux/mpi'
+
+
 
 ##############################################################################
 

--- a/sles12sp3/singularity-openmpi.cyg
+++ b/sles12sp3/singularity-openmpi.cyg
@@ -1,0 +1,45 @@
+##############################################################################
+# maali cygnet file for singularity 
+##############################################################################
+
+read -r -d '' MAALI_MODULE_WHATIS << EOF
+
+Singularity enables users to have full control of their environment. Singularity 
+containers can be used to package entire scientific workflows, software and 
+libraries, and even data.
+
+For further information see https://sylabs.io/singularity
+
+EOF
+
+# specify which compilers we want to build the tool with
+# Should only build it with the system gcc as it just forms the container host
+MAALI_TOOL_COMPILERS="$MAALI_DEFAULT_SYSTEM_GCC"
+
+# specify the architectures we want to build the library on
+MAALI_TOOL_CPU_TARGET="na"
+
+# tool pre-requisites modules needed to install this new tool/package
+MAALI_TOOL_PREREQ="singularity/$MAALI_TOOL_VERSION"
+
+# URL to download the source code from
+MAALI_URL=""
+
+# location we are downloading the source code to
+MAALI_DST=""
+
+# where the unpacked source code is located
+#MAALI_TOOL_BUILD_DIR="$MAALI_BUILD_DIR/$MAALI_TOOL_NAME-$MAALI_TOOL_VERSION"
+MAALI_TOOL_BUILD_DIR=""
+
+# type of tool (eg. apps, devel, python, etc.)
+MAALI_TOOL_TYPE="devel"
+
+# this only creates a module file
+MAALI_REMODULE=1
+
+# for auto-building module files
+MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='/usr/lib64:/pawsey/sles12sp3/devel/broadwell/gcc/4.8.5/openmpi/2.1.2/lib'
+MAALI_MODULE_SET_SINGULARITY_BINDPATH='/astro,/group,/scratch,/pawsey,/etc/dat.conf,/etc/libibverbs.d,/usr/lib64/libdaplofa.so.2,/usr/lib64/libdaplofa.so.2.0.0,/usr/lib64/libdat2.so.2,/usr/lib64/libdat2.so.2.0.0,/usr/lib64/libibverbs,/usr/lib64/libibverbs.so,/usr/lib64/libibverbs.so.1,/usr/lib64/libibverbs.so.1.1.14,/usr/lib64/libmlx5.so,/usr/lib64/libmlx5.so.1,/usr/lib64/libmlx5.so.1.1.14,/usr/lib64/libnl-3.so.200,/usr/lib64/libnl-3.so.200.18.0,/usr/lib64/libnl-cli-3.so.200,/usr/lib64/libnl-cli-3.so.200.18.0,/usr/lib64/libnl-genl-3.so.200,/usr/lib64/libnl-genl-3.so.200.18.0,/usr/lib64/libnl-idiag-3.so.200,/usr/lib64/libnl-idiag-3.so.200.18.0,/usr/lib64/libnl-nf-3.so.200,/usr/lib64/libnl-nf-3.so.200.18.0,/usr/lib64/libnl-route-3.so.200,/usr/lib64/libnl-route-3.so.200.18.0,/usr/lib64/librdmacm.so,/usr/lib64/librdmacm.so.1,/usr/lib64/librdmacm.so.1.0.14,/usr/lib64/libnuma.so.1,/usr/lib64/libpciaccess.so.0,/usr/lib64/libpmi2.so.0,/usr/lib64/libpmi.so.0,/usr/lib64/slurm/libslurmfull.so,/usr/lib64/libosmcomp.so.3,/usr/lib64/libmemkind.so.0,/usr/lib64/libfabric.so.1,/usr/lib64/libpsm2.so.2,/usr/lib64/libpsm_infinipath.so.1,/usr/lib64/libinfinipath.so.4'
+
+##############################################################################


### PR DESCRIPTION
Topaz and Garrawarla:
- added MPICH support
- new singularity-openmpi module with OpenMPI support
Zeus:
- new singularity-openmpi module with OpenMPI support

Tested for CPU applications only right now