### PR TITLE
Singuarity module loads updated intelmpi

### DIFF
--- a/sles12sp3/singularity.cyg
+++ b/sles12sp3/singularity.cyg
@@ -37,7 +37,7 @@ MAALI_TOOL_TYPE="devel"
 
 # for auto-building module files
 MAALI_MODULE_SET_PATH=1
-MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='/usr/lib64:/pawsey/intel/17.0.5/compilers_and_libraries/linux/mpi/intel64/lib'
+MAALI_MODULE_SET_SINGULARITYENV_LD_LIBRARY_PATH='/usr/lib64:/pawsey/intel/18.0.3/compilers_and_libraries/linux/mpi/intel64/lib'
 MAALI_MODULE_SET_SINGULARITY_BINDPATH='/astro,/group,/scratch,/pawsey,/etc/dat.conf,/etc/libibverbs.d,/usr/lib64/libdaplofa.so.2,/usr/lib64/libdaplofa.so.2.0.0,/usr/lib64/libdat2.so.2,/usr/lib64/libdat2.so.2.0.0,/usr/lib64/libibverbs,/usr/lib64/libibverbs.so,/usr/lib64/libibverbs.so.1,/usr/lib64/libibverbs.so.1.1.14,/usr/lib64/libmlx5.so,/usr/lib64/libmlx5.so.1,/usr/lib64/libmlx5.so.1.1.14,/usr/lib64/libnl-3.so.200,/usr/lib64/libnl-3.so.200.18.0,/usr/lib64/libnl-cli-3.so.200,/usr/lib64/libnl-cli-3.so.200.18.0,/usr/lib64/libnl-genl-3.so.200,/usr/lib64/libnl-genl-3.so.200.18.0,/usr/lib64/libnl-idiag-3.so.200,/usr/lib64/libnl-idiag-3.so.200.18.0,/usr/lib64/libnl-nf-3.so.200,/usr/lib64/libnl-nf-3.so.200.18.0,/usr/lib64/libnl-route-3.so.200,/usr/lib64/libnl-route-3.so.200.18.0,/usr/lib64/librdmacm.so,/usr/lib64/librdmacm.so.1,/usr/lib64/librdmacm.so.1.0.14'
 MAALI_MODULE_SET_SINGULARITY_CACHEDIR='os.getenv\(\"MYGROUP\"\)..\"/.singularity\"'
 MAALI_MODULE_QUOTES_SINGULARITY_CACHEDIR=off


### PR DESCRIPTION
Marco, due to the problems observed with snappyHexMesh in OpenFOAM containers, I think we should upgrade the intelmpi to @18.0.3